### PR TITLE
remove getApproved check

### DIFF
--- a/contracts/ManaBank.sol
+++ b/contracts/ManaBank.sol
@@ -95,10 +95,6 @@ contract ManaBank is ERC20, ReentrancyGuard {
                 tokenContract.ownerOf(tokenId) == msg.sender,
                 "ManaBank: You must own all tokens being deposited for mana"
             );
-            require(
-                tokenContract.getApproved(tokenId) == address(this),
-                "ManaBank: Must approve transfer on all tokens being deposited for mana"
-            );
 
             tokenContract.transferFrom(msg.sender, address(this), tokenId);
             _depositToken(tokenAddress, tokenId);


### PR DESCRIPTION
1. `getApproved` would always return `address(0)` in our case, because we called `setApprovalForAll` rather than asking approval for individual token.
2. approved is already checked in `transferFrom`: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/ERC721.sol#L145.

@lsankar4033 FYI